### PR TITLE
dev: upgrade deprecated actions on GH workflows

### DIFF
--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -1,4 +1,3 @@
-
 name: Build and push to Dockerhub
 
 on:
@@ -7,7 +6,7 @@ on:
       repo:
         type: string
         required: false
-        default: 'codecov'
+        default: "codecov"
       cache:
         type: boolean
         default: true
@@ -20,7 +19,7 @@ on:
       push:
         type: boolean
         default: true
-        description: 'Whether to push the image'
+        description: "Whether to push the image"
 
 env:
   DOCKERHUB_REPO: ${{ inputs.repo }}
@@ -38,7 +37,7 @@ jobs:
       - name: Cache Image
         id: cache-image
         if: inputs.cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-${{ inputs.image_name }}
         with:
@@ -58,7 +57,7 @@ jobs:
           make save.${{ inputs.image_name }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3.1.0
         if: ${{ inputs.push && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         with:
           username: ${{ secrets.CODECOV_DEVOPS_DOCKER_USERNAME }}

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,4 +1,3 @@
-
 name: Build App
 
 on:
@@ -26,7 +25,7 @@ jobs:
       - id: "auth"
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1.1.1"
+        uses: "google-github-actions/auth@v2.1.2"
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
@@ -40,7 +39,7 @@ jobs:
       - name: Cache Requirements
         id: cache-requirements
         if: inputs.cache_requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -52,7 +51,7 @@ jobs:
 
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -1,4 +1,3 @@
-
 name: Push Image for Environment
 
 on:
@@ -17,11 +16,11 @@ on:
       push_rolling:
         type: boolean
         default: false
-        description: 'Whether to push the rolling image'
+        description: "Whether to push the rolling image"
       push_release:
         type: boolean
         default: false
-        description: 'Whether to push the release image'
+        description: "Whether to push the release image"
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -44,7 +43,7 @@ jobs:
         run: echo short_sha="${SHA:0:7}" >> $GITHUB_OUTPUT
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:
@@ -56,7 +55,7 @@ jobs:
           docker load --input app.tar
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1.1.1"
+        uses: "google-github-actions/auth@v2.1.2"
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
@@ -106,7 +105,7 @@ jobs:
           fetch-depth: 0
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:
@@ -117,7 +116,7 @@ jobs:
         run: |
           docker load --input app.tar
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.CODECOV_DEVOPS_DOCKER_USERNAME }}
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
@@ -136,7 +135,7 @@ jobs:
           fetch-depth: 0
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:
@@ -147,7 +146,7 @@ jobs:
         run: |
           docker load --input app.tar
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.CODECOV_DEVOPS_DOCKER_USERNAME }}
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}

--- a/.github/workflows/run-ats.yml
+++ b/.github/workflows/run-ats.yml
@@ -1,4 +1,3 @@
-
 name: Run ATS
 
 on:
@@ -10,7 +9,7 @@ on:
       app_container_name:
         type: string
         required: false
-        default: 'app'
+        default: "app"
       use_action:
         type: boolean
         required: false
@@ -19,27 +18,27 @@ on:
         required: false
         default: false
         type: boolean
-        description: 'Whether to install the Codecov CLI. Set to false if you have previously installed the CLI.'
+        description: "Whether to install the Codecov CLI. Set to false if you have previously installed the CLI."
       run_tests:
         required: false
         default: true
         type: boolean
-        description: 'Whether to run the tests with the given command in the container. If set to true, this will run the test command and upload to Codecov'
+        description: "Whether to run the tests with the given command in the container. If set to true, this will run the test command and upload to Codecov"
       test_command:
         required: false
-        default: 'python -m pytest --cov=./'
+        default: "python -m pytest --cov=./"
         type: string
-        description: 'Command to run in container to execute tests. Required when run_tests is true. This should be `pytest` with the desired args at this point.'
+        description: "Command to run in container to execute tests. Required when run_tests is true. This should be `pytest` with the desired args at this point."
       codecov_cli_upload_args:
         required: false
         type: string
-        default: ''
-        description: 'List of args to pass to cli on upload. This is kind of a hack pending a more robust solution'
+        default: ""
+        description: "List of args to pass to cli on upload. This is kind of a hack pending a more robust solution"
       codecov_cli_yml_path:
         required: false
         type: string
-        default: '--codecov-yml-path=codecov_cli.yml'
-        description: 'Path to codecov cli yml. Currently expected to include flag as well --codecov-yml-path=codecov_cli.yml for ex.'
+        default: "--codecov-yml-path=codecov_cli.yml"
+        description: "Path to codecov cli yml. Currently expected to include flag as well --codecov-yml-path=codecov_cli.yml for ex."
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -54,7 +53,7 @@ jobs:
           fetch-depth: 0
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,3 @@
-
 name: Run Tests
 
 on:
@@ -25,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: Cache App
         id: cache-app
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-app
         with:

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -5,11 +5,11 @@ on:
       push_rolling:
         type: boolean
         default: false
-        description: 'Whether to push the rolling image'
+        description: "Whether to push the rolling image"
       push_release:
         type: boolean
         default: false
-        description: 'Whether to push the release image'
+        description: "Whether to push the release image"
       repo:
         type: string
         required: true
@@ -30,7 +30,7 @@ jobs:
       - id: "auth"
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' && inputs.cache_requirements }}
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1.1.1"
+        uses: "google-github-actions/auth@v2.1.2"
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ secrets.CODECOV_GCP_WIDP }}
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Requirements
         id: cache-requirements
         if: inputs.cache_requirements
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-requirements
         with:
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Self hosted
         id: cache-self-hosted
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-self-hosted
         with:
@@ -73,7 +73,7 @@ jobs:
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && inputs.cache_requirements }}
         run: |
-          make build.requirements      
+          make build.requirements
 
       - name: Load built image
         if: ${{ steps.cache-self-hosted.outputs.cache-hit == 'true' }}
@@ -88,7 +88,7 @@ jobs:
 
   self-hosted:
     name: Push Self Hosted Image
-    needs: [ build-self-hosted ]
+    needs: [build-self-hosted]
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment: self-hosted
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
       - name: Cache Self hosted
         id: cache-self-hosted
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-self-hosted
         with:
@@ -111,7 +111,7 @@ jobs:
         run: |
           make load.self-hosted
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.CODECOV_DEVOPS_DOCKER_USERNAME }}
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
@@ -121,7 +121,7 @@ jobs:
           make push.self-hosted-rolling
   self-hosted-release:
     name: Push Self Hosted Release Image
-    needs: [ build-self-hosted ]
+    needs: [build-self-hosted]
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment: self-hosted
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 0
       - name: Cache Self hosted
         id: cache-self-hosted
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-self-hosted
         with:
@@ -144,7 +144,7 @@ jobs:
         run: |
           make load.self-hosted
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v3.1.0
         with:
           username: ${{ secrets.CODECOV_DEVOPS_DOCKER_USERNAME }}
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}


### PR DESCRIPTION
## Description

Saw that there were a lot of deprecation warnings on various github actions we were using. Went through and bumped all of those up to latest, confirming there shouldn't be any breaking changes on each.


**Changelogs**

[Google Github Actions](https://github.com/google-github-actions/auth/releases): 1.1.1 -> 2.1.2
[Actions/Cache](https://github.com/actions/cache/releases/tag/v4.0.2): v3 -> v4
[Docker Login Action](https://github.com/docker/login-action/releases): 1.14.1 -> 3.1


## Screenshot

![Screenshot 2024-05-10 at 10 28 32 AM](https://github.com/codecov/gha-workflows/assets/159853603/746e26a7-6d20-49da-9012-0b32b28e8cec)
