### PR TITLE
Update mypy.yml

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,6 +2,12 @@ name: Patch typing check
 
 on:
   workflow_call:
+    inputs:
+      extra_config:
+        type: string
+        required: false
+        default: ''
+        description: 'Extra configuration for mypy'
 
 jobs:
   static-type-check:
@@ -21,4 +27,4 @@ jobs:
           **/*.py
     - name: Run if any of the listed files above is changed
       if: steps.changed-py-files.outputs.any_changed == 'true'
-      run: mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports
+      run: mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports ${{ inputs.extra_config }}


### PR DESCRIPTION
Running `mypy` in the worker always fails (the command, not the type checks, but those fail too). I believe that it's because of how mypy processes imports. I was able to fix it locally by using the `--explicit-package-bases` option. But to be able to pass that in the CI we need to expand this a little bit.