### PR TITLE
add workflow to post comment comparing updated deps

### DIFF
--- a/.github/workflows/diff-dep.yml
+++ b/.github/workflows/diff-dep.yml
@@ -1,0 +1,80 @@
+name: Post dependency compare link
+
+on:
+  workflow_call:
+    inputs:
+      dep:
+        type: string
+        required: true
+jobs:
+  post-comment:
+    name: Post comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Generate a GitHub link to a page that displays all commits/changes between
+      # the old dependency version and the new one, or an empty string if the dependency
+      # wasn't changed.
+      - name: Get compare URL
+        id: get-compare-url
+        run: |
+          compare_url=$(git diff -r ${{ github.event.pull_request.base.sha }} \
+            | grep ${{ inputs.dep }}\/archive \
+            | cut -d '/' -f 7 \
+            | cut -d '.' -f 1 \
+            | awk 'NR%2{printf "https://github.com/codecov/${{ inputs.dep }}/compare/%s..",$0;next;}1')
+          echo "Compare URL: $compare_url"
+          echo "COMPARE_URL=$compare_url" >> $GITHUB_OUTPUT
+
+      # If our dep was changed, check if we've already made a comment and cached its ID
+      - name: Cache check
+        id: cache-check
+        if: steps.get-compare-url.outputs.COMPARE_URL != ''
+        uses: actions/cache@v4
+        with:
+          path: comment-id.txt
+          key: comment-id-pr-${{ github.event.pull_request.number }}
+
+      # If our dep was changed and there is no comment ID in the cache, create a new comment
+      - name: Create comment
+        id: create-comment
+        if: ${{ steps.get-compare-url.outputs.COMPARE_URL != '' && steps.cache-check.outputs.cache-hit != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This PR includes changes to `${{ inputs.dep }}`. Please review them here: ${{ steps.get-compare-url.outputs.COMPARE_URL }}'
+            })
+
+      # Whether we got it from cache or the comment created above, put the comment ID in
+      # the cached output file + set it as the output of this step
+      - name: Get comment ID
+        id: get-comment-id
+        if: steps.get-compare-url.outputs.COMPARE_URL != ''
+        run: |
+          if [ ! -f comment-id.txt ]; then
+            echo "Comment was newly created; getting ID out of response"
+            echo '${{ steps.create-comment.outputs.result }}' | jq '.data.id' > comment-id.txt
+          fi
+          echo "Comment ID is $(cat comment-id.txt)"
+          echo "COMMENT_ID=$(cat comment-id.txt)" >> $GITHUB_OUTPUT
+
+      # If we have changes to our dep, and we got a comment ID from the cache, update the comment.
+      - name: Update comment
+        id: update-comment
+        if: ${{ steps.get-compare-url.outputs.COMPARE_URL != '' && steps.cache-check.outputs.cache-hit == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            return github.rest.issues.updateComment({
+              comment_id: ${{ steps.get-comment-id.outputs.COMMENT_ID }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This PR includes changes to `${{ inputs.dep }}`. Please review them here: ${{ steps.get-compare-url.outputs.COMPARE_URL }}'
+            })


### PR DESCRIPTION
this is a reusable workflow that will automatically post/update a PR comment when `shared` is updated. the comment contains a link to a GitHub page that will show all of the commits/changes between the old shared version and the new shared version

here's a screenshot that shows a comment that was edited in place when the PR was updated
<img width="687" alt="Screenshot 2024-09-04 at 5 01 02 PM" src="https://github.com/user-attachments/assets/eaa96699-423b-49bc-9b86-f2e36c58659f">

it takes the dep as an input, so we could actually use this for the test results parser or other git-based pip dependencies. if somebody wants to teach it javascript, we could use it for gazebo too

you use it like this:
```
jobs:
  post-dep-comment:
    name: Post dep comment
    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@pr30
    with:
      dep: 'shared'
```

test repo / PR where i tested this: https://github.com/codecov/test-workflow/pull/2
- [Workflow run when no comment already exists](https://github.com/codecov/test-workflow/actions/runs/10711030220/job/29699670994?pr=2)
- [Workflow run when a comment already exists ](https://github.com/codecov/test-workflow/actions/runs/10711294051/job/29699692315?pr=2)