### PR TITLE
fix diff-dep: only look at requirements.in + get correct base for diff

### DIFF
--- a/.github/workflows/diff-dep.yml
+++ b/.github/workflows/diff-dep.yml
@@ -6,6 +6,9 @@ on:
       dep:
         type: string
         required: true
+      reqs_file:
+        type: string
+        default: 'requirements.in'
 jobs:
   post-comment:
     name: Post comment
@@ -13,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       # Generate a GitHub link to a page that displays all commits/changes between
       # the old dependency version and the new one, or an empty string if the dependency
@@ -21,11 +24,11 @@ jobs:
       - name: Get compare URL
         id: get-compare-url
         run: |
-          compare_url=$(git diff -r ${{ github.event.pull_request.base.sha }} \
+          compare_url=$(git diff -r HEAD^ ${{ inputs.reqs_file }} \
             | grep ${{ inputs.dep }}\/archive \
             | cut -d '/' -f 7 \
             | cut -d '.' -f 1 \
-            | awk 'NR%2{printf "https://github.com/codecov/${{ inputs.dep }}/compare/%s..",$0;next;}1')
+            | awk 'NR%2{printf "https://github.com/codecov/${{ inputs.dep }}/compare/%s...",$0;next;}1')
           echo "Compare URL: $compare_url"
           echo "COMPARE_URL=$compare_url" >> $GITHUB_OUTPUT
 
@@ -60,7 +63,7 @@ jobs:
         run: |
           if [ ! -f comment-id.txt ]; then
             echo "Comment was newly created; getting ID out of response"
-            echo "${{ steps.create-comment.outputs.result }}" | jq '.data.id' > comment-id.txt
+            echo '${{ steps.create-comment.outputs.result }}' | jq '.data.id' > comment-id.txt
           fi
           echo "Comment ID is $(cat comment-id.txt)"
           echo "COMMENT_ID=$(cat comment-id.txt)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
job failed in worker and api for a few reasons:
- called without PR comment permissions (fixed at callsite, not here. don't know why this wasn't a problem in the test repo)
- emitted a comparison URL for both `requirements.in` and `requirements.txt` (i only had one in the test repo, forgot to handle this)
- using " instead of ' to quote a GHA expression expanded to invalid syntax. don't know why this wasn't a problem in the test repo