### PR TITLE
Update `mypy` and run it on all the files

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -6,25 +6,16 @@ on:
       extra_config:
         type: string
         required: false
-        default: ''
-        description: 'Extra configuration for mypy'
+        default: ""
+        description: "Extra configuration for mypy"
 
 jobs:
   static-type-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v3
-      with:
-        python-version: '3.12'
-    - run: pip install mypy==1.10.0
-    - name: Get Python changed files
-      id: changed-py-files
-      uses: tj-actions/changed-files@v44.3.0
-      with:
-        files: |
-          *.py
-          **/*.py
-    - name: Run if any of the listed files above is changed
-      if: steps.changed-py-files.outputs.any_changed == 'true'
-      run: mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports ${{ inputs.extra_config }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mypy==1.13.0
+      - run: mypy . --ignore-missing-imports ${{ inputs.extra_config }}


### PR DESCRIPTION
Running `mypy` only on the changed files is the wrong thing to do, as typing changes in one file can have an effect on upstream code that imports said file.

Apart from removing that file filtering, this also updates the `setup-python` GHA, and `mypy` itself.

---

TBH, I don’t think this should be a centralized workflow at all. `mypy` should really be installed as a dev dependency per-repo, and run within that repo, using the local `.python-version` as well, so the python and mypy versions are defined within that repo.
As both python updates and mypy updates could have an effect on the results of type checking.