### PR TITLE
Expose JUnit files in CI as an artifact

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,6 +52,11 @@ jobs:
         if: ${{ !cancelled() && inputs.run_integration == true }}
         run: |
           make test_env.run_integration
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: junitfiles
+          path: ./*junit*.xml
       ## Don't upload on forks for now.
       - name: upload using codecovcli
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}


### PR DESCRIPTION
This will make it easier to debug test files that have, for whatever reason, not been uploaded.