### PR TITLE
dev: Create split test workflow for suites using pytest-split

### DIFF
--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -1,0 +1,74 @@
+name: Run Tests Split
+
+on:
+  workflow_call:
+    inputs:
+      run_integration:
+        required: false
+        type: boolean
+        default: true
+      repo:
+        type: string
+        required: true
+env:
+  AR_REPO: ${{ inputs.repo }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        group: [1, 2, 3, 4, 5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cache App
+        id: cache-app
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-app
+        with:
+          path: |
+            app.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
+      - name: Load built image
+        run: |
+          docker load --input app.tar
+      - name: Install docker compose
+        run: |
+          sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+      - name: Bring test env up
+        run: |
+          make test_env.up
+      - name: Prepare for tests
+        run: |
+          make test_env.prepare
+          make test_env.check_db
+      - name: Run unit tests
+        run: |
+          make test_env.run_unit --group ${{ matrix.group }}
+      - name: Run integration tests
+        if: inputs.run_integration == true
+        run: |
+          make test_env.run_integration --group ${{ matrix.group }}
+      ## Don't upload on forks for now.
+      - name: upload using codecovcli
+        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_URL }}
+      - name: upload using codecovcli staging
+        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN_STAGING }} CODECOV_URL=${{ secrets.CODECOV_STAGING_URL }}
+      - name: upload using codecovcli qa
+        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_QA_URL }}
+      - name: upload using codecovcli public qa
+        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_PUBLIC_QA_URL }}


### PR DESCRIPTION
This PR creates a new test-run workflow to split the test suite into 5 groups and run them in parallel, ideally leading to a massively decreased runtime for our test suite (API)