### PR TITLE
fix: update split / group var inputs

### DIFF
--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -10,6 +10,10 @@ on:
       repo:
         type: string
         required: true
+      split:
+        type: number
+        required: false
+        default: 5
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -50,11 +54,11 @@ jobs:
           make test_env.check_db
       - name: Run unit tests
         run: |
-          make test_env.run_unit --group ${{ matrix.group }}
+          make test_env.run_unit GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }}
       - name: Run integration tests
         if: inputs.run_integration == true
         run: |
-          make test_env.run_integration --group ${{ matrix.group }}
+          make test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }}
       ## Don't upload on forks for now.
       - name: upload using codecovcli
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}


### PR DESCRIPTION
This PR updates split and group to be passed in variables to the Makefile in https://github.com/codecov/codecov-api/pull/1144/files