### PR TITLE
monorepo prep: use contextual cache names, add working_directory input

### DIFF
--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - name: Cache Image
         id: cache-image

--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -20,6 +20,9 @@ on:
         type: boolean
         default: true
         description: "Whether to push the image"
+      working_directory:
+        type: string
+        default: .
 
 env:
   DOCKERHUB_REPO: ${{ inputs.repo }}
@@ -30,6 +33,9 @@ jobs:
   build-and-push:
     name: Build and push
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +48,7 @@ jobs:
           cache-name: cache-${{ inputs.image_name }}
         with:
           path: |
-            ${{ inputs.image_name }}.tar
+            ${{ inputs.working_directory }}/${{ inputs.image_name }}.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load built image

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          submodules: 'recursive'
       - id: "auth"
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         name: "Authenticate to Google Cloud"

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,6 +9,9 @@ on:
       cache_requirements:
         type: boolean
         default: true
+      working_directory:
+        type: string
+        default: .
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -17,6 +20,9 @@ jobs:
   build:
     name: Build App
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,8 +50,8 @@ jobs:
           cache-name: cache-requirements
         with:
           path: |
-            requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/docker/Dockerfile.requirements') }}
+            ${{ inputs.working_directory }}/requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles(format('{0}/**/requirements.txt', inputs.working_directory)) }}-${{ hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.working_directory)) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -56,7 +62,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -47,7 +47,7 @@ jobs:
         if: inputs.cache_requirements
         uses: actions/cache@v4
         env:
-          cache-name: cache-requirements
+          cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
             ${{ inputs.working_directory }}/requirements.tar
@@ -59,7 +59,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar

--- a/.github/workflows/codecov-startup.yml
+++ b/.github/workflows/codecov-startup.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          submodules: 'recursive'
       - name: Install CLI
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |

--- a/.github/workflows/codecov-startup.yml
+++ b/.github/workflows/codecov-startup.yml
@@ -3,11 +3,18 @@ name: Codecov Startup
 
 on:
   workflow_call:
+    inputs:
+      working_directory:
+        type: string
+        default: .
 
 jobs:
   codecovstartup:
     name: Codecov Startup
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - name: Import GPG key
         id: import-gpg

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,18 @@ name: Run Lint
 
 on:
   workflow_call:
+    inputs:
+      working_directory:
+        type: string
+        default: .
 
 jobs:
   lint:
     name: Run Lint
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Install dependencies
         run: make lint.install
       - name: Check

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,10 +8,16 @@ on:
         required: false
         default: ""
         description: "Extra configuration for mypy"
+      working_directory:
+        type: string
+        default: .
 
 jobs:
   static-type-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -20,6 +20,8 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -24,6 +24,9 @@ on:
       working_directory:
         type: string
         default: .
+      sentry_project:
+        type: string
+        required: false
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -88,7 +91,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.CODECOV_SENTRY_RELEASE_TOKEN }}
           SENTRY_ORG: ${{ secrets.CODECOV_SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.CODECOV_SENTRY_PROJECT }}
+          SENTRY_PROJECT: ${{ inputs.sentry_project != '' && inputs.sentry_project || secrets.CODECOV_SENTRY_PROJECT }}
         with:
           environment: ${{ inputs.environment }}
           version: ${{ inputs.environment }}-release-${{ steps.sha.outputs.short_sha }}

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -51,7 +51,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar
@@ -109,7 +109,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar
@@ -142,7 +142,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
         description: "Whether to push the release image"
+      working_directory:
+        type: string
+        default: .
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -29,6 +32,9 @@ jobs:
   push-environment:
     name: Push ${{ inputs.environment }} Image
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     environment: ${{ inputs.environment }}
     if: github.repository_owner == 'codecov' && !inputs.push_rolling && !inputs.push_release
     steps:
@@ -48,7 +54,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -86,10 +92,14 @@ jobs:
           environment: ${{ inputs.environment }}
           version: ${{ inputs.environment }}-release-${{ steps.sha.outputs.short_sha }}
           ignore_missing: true
+          working_directory: ${{ inputs.working_directory }}
   rolling:
     name: Push Rolling Image
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,7 +112,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -120,6 +130,9 @@ jobs:
     name: Push Release Image
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -132,7 +145,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Get Release SHA
         env:
           SHA: ${{ github.sha }}
@@ -105,6 +106,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache App
         id: cache-app
         uses: actions/cache@v4
@@ -138,6 +140,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache App
         id: cache-app
         uses: actions/cache@v4

--- a/.github/workflows/run-ats.yml
+++ b/.github/workflows/run-ats.yml
@@ -61,7 +61,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar

--- a/.github/workflows/run-ats.yml
+++ b/.github/workflows/run-ats.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache App
         id: cache-app
         uses: actions/cache@v4

--- a/.github/workflows/run-ats.yml
+++ b/.github/workflows/run-ats.yml
@@ -39,6 +39,9 @@ on:
         type: string
         default: "--codecov-yml-path=codecov_cli.yml"
         description: "Path to codecov cli yml. Currently expected to include flag as well --codecov-yml-path=codecov_cli.yml for ex."
+      working_directory:
+        type: string
+        default: .
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -46,6 +49,9 @@ jobs:
   ats:
     name: ATS
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,7 +64,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -89,6 +95,8 @@ jobs:
           make test_env.label_analysis CODECOV_STATIC_TOKEN=${{ secrets.STATIC_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_ATS_URL }}
           make test_env.ats CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_ATS_URL }}
       - id: test-upload-action
+        # NOTE: `defaults.runs.working-directory` will not be propagated into this action.
+        # This action will only work with the default working directory (the repo root).
         uses: codecov/codecov-ats-docker@main
         if: inputs.use_action
         name: Run tests and upload to Codecov via action

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -61,7 +61,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache App
         id: cache-app
         uses: actions/cache@v4
@@ -128,6 +129,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
 
       - name: Download coverage
         id: download_coverage

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -17,6 +17,10 @@ on:
       flag_prefix:
         type: string
         default: ''
+      working_directory:
+        type: string
+        default: .
+
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -40,6 +44,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     needs: [prepare_groups]
     strategy:
       matrix:
@@ -57,7 +64,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -85,17 +92,20 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: coveragefiles-${{ matrix.group }}
-          path: ./*.coverage.xml
+          path: ${{ inputs.working_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junitfiles-${{ matrix.group }}
-          path: ./*junit*.xml
+          path: ${{ inputs.working_directory }}/*junit*.xml
 
   upload:
     name: Upload to Codecov
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     needs: [test]
     strategy:
       matrix:
@@ -120,12 +130,14 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage
+        id: download_coverage
         uses: actions/download-artifact@v4
         with:
           pattern: coveragefiles-*
           merge-multiple: true
 
       - name: Download test results
+        id: download_test_results
         uses: actions/download-artifact@v4
         with:
           pattern: junitfiles-*
@@ -134,7 +146,7 @@ jobs:
       - name: Uploading unit test coverage (${{ matrix.name }})
         uses: codecov/codecov-action@v5
         with:
-          files: ./unit.*.coverage.xml
+          files: ${{ steps.download_coverage.outputs.download-path }}/unit.*.coverage.xml
           flags: ${{ format('{0}unit', inputs.flag_prefix) }}
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
@@ -142,12 +154,13 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Uploading integration test coverage (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/codecov-action@v5
         with:
-          files: ./integration.*.coverage.xml
+          files: ${{ steps.download_coverage.outputs.download-path }}/integration.*.coverage.xml
           flags: ${{ format('{0}integration', inputs.flag_prefix) }}
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
@@ -155,11 +168,26 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
+          working-directory: ${{ inputs.working_directory }}
+
+      # The test result action doesn't accept globs in its `files` argument
+      # so this step expands the globs into a comma-separated list of files
+      - name: Expand globs for test result files
+        id: junit_files
+        # echo ./unit.*.junit.xml                 => ./unit.1.junit.xml ./unit.2.junit.xml ./unit.3.junit.xml
+        # echo ./unit.*.junit.xml | sed 's/ /,/g' => ./unit.1.junit.xml,./unit.2.junit.xml,./unit.3.junit.xml
+        run: |
+          base_path="${{ steps.download_test_results.outputs.download-path }}"
+          unit_junit_files=$(echo $base_path/unit.*.junit.xml | sed 's/ /,/g')
+          integration_junit_files=$(echo $base_path/integration.*.junit.xml | sed 's/ /,/g')
+
+          echo "unit_junit_files=$unit_junit_files" >> $GITHUB_OUTPUT
+          echo "integration_junit_files=$integration_junit_files" >> $GITHUB_OUTPUT
 
       - name: Uploading unit test results (${{ matrix.name }})
         uses: codecov/test-results-action@v1
         with:
-          files: ./unit.*.junit.xml
+          files: ${{ steps.junit_files.outputs.unit_junit_files }}
           flags: ${{ format('{0}unit', inputs.flag_prefix) }}
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
@@ -167,12 +195,13 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/test-results-action@v1
         with:
-          files: ./integration.*.junit.xml
+          files: ${{ steps.junit_files.outputs.integration_junit_files }}
           flags: ${{ format('{0}integration', inputs.flag_prefix) }}
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
@@ -180,3 +209,4 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
+          working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,10 @@ on:
       flag_prefix:
         type: string
         default: ''
+      working_directory:
+        type: string
+        default: .
+
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -20,6 +24,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +39,7 @@ jobs:
           cache-name: cache-app
         with:
           path: |
-            app.tar
+            ${{ inputs.working_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -60,17 +67,20 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: coveragefiles
-          path: ./*.coverage.xml
+          path: ${{ inputs.working_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junitfiles
-          path: ./*junit*.xml
+          path: ${{ inputs.working_directory }}/*junit*.xml
 
   upload:
     name: Upload to Codecov
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     needs: [test]
     strategy:
       matrix:
@@ -95,11 +105,13 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage
+        id: download_coverage
         uses: actions/download-artifact@v4
         with:
           name: coveragefiles
 
       - name: Download test results
+        id: download_test_results
         uses: actions/download-artifact@v4
         with:
           name: junitfiles
@@ -107,7 +119,7 @@ jobs:
       - name: Uploading unit test coverage (${{ matrix.name }})
         uses: codecov/codecov-action@v5
         with:
-          files: ./unit.coverage.xml
+          files: ${{ steps.download_coverage.outputs.download-path }}/unit.coverage.xml
           flags: ${{ format('{0}unit', inputs.flag_prefix) }}
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
@@ -115,12 +127,13 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Uploading integration test coverage (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/codecov-action@v5
         with:
-          files: ./integration.coverage.xml
+          files: ${{ steps.download_coverage.outputs.download-path }}/integration.coverage.xml
           flags: ${{ format('{0}integration', inputs.flag_prefix) }}
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
@@ -128,11 +141,12 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Uploading unit test results (${{ matrix.name }})
         uses: codecov/test-results-action@v1
         with:
-          files: ./unit.junit.xml
+          files: ${{ steps.download_test_results.outputs.download-path }}/unit.junit.xml
           flags: ${{ format('{0}unit', inputs.flag_prefix) }}
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
@@ -140,12 +154,13 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
+          working-directory: ${{ inputs.working_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/test-results-action@v1
         with:
-          files: ./integration.junit.xml
+          files: ${{ steps.download_test_results.outputs.download-path }}/integration.junit.xml
           flags: ${{ format('{0}integration', inputs.flag_prefix) }}
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
@@ -153,3 +168,4 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
+          working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache App
         id: cache-app
         uses: actions/cache@v4
@@ -103,6 +104,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
 
       - name: Download coverage
         id: download_coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
         id: cache-app
         uses: actions/cache@v4
         env:
-          cache-name: cache-app
+          cache-name: ${{ inputs.repo }}-app
         with:
           path: |
             ${{ inputs.working_directory }}/app.tar

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -53,7 +53,7 @@ jobs:
         if: inputs.cache_requirements
         uses: actions/cache@v4
         env:
-          cache-name: cache-requirements
+          cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
             ${{ inputs.working_directory }}/requirements.tar
@@ -65,7 +65,7 @@ jobs:
         id: cache-self-hosted
         uses: actions/cache@v4
         env:
-          cache-name: cache-self-hosted
+          cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
             ${{ inputs.working_directory }}/self-hosted-runtime.tar
@@ -111,7 +111,7 @@ jobs:
         id: cache-self-hosted
         uses: actions/cache@v4
         env:
-          cache-name: cache-self-hosted
+          cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
             ${{ inputs.working_directory }}/self-hosted-runtime.tar
@@ -147,7 +147,7 @@ jobs:
         id: cache-self-hosted
         uses: actions/cache@v4
         env:
-          cache-name: cache-self-hosted
+          cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
             ${{ inputs.working_directory }}/self-hosted-runtime.tar

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - id: "auth"
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' && inputs.cache_requirements }}
@@ -107,6 +109,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache Self hosted
         id: cache-self-hosted
         uses: actions/cache@v4
@@ -143,6 +146,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'recursive'
       - name: Cache Self hosted
         id: cache-self-hosted
         uses: actions/cache@v4

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -16,6 +16,10 @@ on:
       cache_requirements:
         type: boolean
         default: true
+      working_directory:
+        type: string
+        default: .
+
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -23,6 +27,9 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted App
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,8 +56,8 @@ jobs:
           cache-name: cache-requirements
         with:
           path: |
-            requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/docker/Dockerfile.requirements') }}
+            ${{ inputs.working_directory }}/requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles(format('{0}/**/requirements.txt', inputs.working_directory)) }}-${{ hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.working_directory)) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -61,8 +68,8 @@ jobs:
           cache-name: cache-self-hosted
         with:
           path: |
-            self-hosted-runtime.tar
-            self-hosted.tar
+            ${{ inputs.working_directory }}/self-hosted-runtime.tar
+            ${{ inputs.working_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache
@@ -91,6 +98,9 @@ jobs:
     needs: [build-self-hosted]
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     environment: self-hosted
     steps:
       - name: Checkout
@@ -104,8 +114,8 @@ jobs:
           cache-name: cache-self-hosted
         with:
           path: |
-            self-hosted-runtime.tar
-            self-hosted.tar
+            ${{ inputs.working_directory }}/self-hosted-runtime.tar
+            ${{ inputs.working_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -124,6 +134,9 @@ jobs:
     needs: [build-self-hosted]
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
     environment: self-hosted
     steps:
       - name: Checkout
@@ -137,8 +150,8 @@ jobs:
           cache-name: cache-self-hosted
         with:
           path: |
-            self-hosted-runtime.tar
-            self-hosted.tar
+            ${{ inputs.working_directory }}/self-hosted-runtime.tar
+            ${{ inputs.working_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |


### PR DESCRIPTION
currently we use cache names like `cache-requirements`. when worker and api are in different repositories, that's fine - their caches will remain separate. but when we move them all into a monorepo, they will collide. this PR includes the image repo argument in the cache name

our workflows all also assume they are operating out of the repository root. https://github.com/codecov/umbrella, however, will probably organize them in a structure like this:
```
- apps
  - worker
  - codecov-api
- libs
  - shared
```
so this PR adds a `working_directory` input and uses it as the default working directory for all `run:`-type steps. we can run worker tests in umbrella by calling the `run-tests.yml` workflow with `working_directory: apps/worker`. some things to note:
- the default is `.` so no change should be necessary to the current separate repos. this is just helpful for umbrella
- `uses:`-type steps (like cache actions) will not use the default working directory. for these steps, paths need to be prefixed with `${{ inputs.working_directory }}/`

down the line we should absorb these workflows into the monorepo but fine for now