### PR TITLE
use codecov actions to upload instead of the cli

### DIFF
--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -14,16 +14,37 @@ on:
         type: number
         required: false
         default: 5
+      flag_prefix:
+        type: string
+        default: ''
 env:
   AR_REPO: ${{ inputs.repo }}
 
 jobs:
+  # Create a list from 1 to `inputs.split` to use as our matrix for `test`
+  prepare_groups:
+    name: Prepare groups
+    runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.prepare_groups.outputs.groups }}
+    # echo {1..5}                                => 1 2 3 4 5
+    # echo {1..5} | sed 's/ /, /g'               => 1, 2, 3, 4, 5
+    # echo '[$(echo {1..5} | sed 's/ /, /g')]'   => [1, 2, 3, 4, 5]
+    steps:
+      - name: Prepare groups
+        id: prepare_groups
+        run: |
+          group_list=$(echo "[$(echo {1..${{ inputs.split }}} | sed 's/ /, /g')]")
+          echo "groups=$group_list" >> $GITHUB_OUTPUT
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [prepare_groups]
     strategy:
       matrix:
-        group: [1, 2, 3, 4, 5]
+        # Parse our group list into a JSON object
+        group: ${{ fromJSON(needs.prepare_groups.outputs.groups) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,20 +80,103 @@ jobs:
         if: inputs.run_integration == true
         run: |
           make test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }}
-      ## Don't upload on forks for now.
-      - name: upload using codecovcli
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_URL }}
-      - name: upload using codecovcli staging
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN_STAGING }} CODECOV_URL=${{ secrets.CODECOV_STAGING_URL }}
-      - name: upload using codecovcli qa
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_QA_URL }}
-      - name: upload using codecovcli public qa
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_PUBLIC_QA_URL }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: coveragefiles-${{ matrix.group }}
+          path: ./*.coverage.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: junitfiles-${{ matrix.group }}
+          path: ./*junit*.xml
+
+  upload:
+    name: Upload to Codecov
+    runs-on: ubuntu-latest
+    needs: [test]
+    strategy:
+      matrix:
+        include:
+          - codecov_url_secret: CODECOV_URL
+            codecov_token_secret: CODECOV_ORG_TOKEN
+            name: prod
+          - codecov_url_secret: CODECOV_STAGING_URL
+            codecov_token_secret: CODECOV_ORG_TOKEN_STAGING
+            name: staging
+          - codecov_url_secret: CODECOV_QA_URL
+            codecov_token_secret: CODECOV_QA_ORG
+            name: qa
+          - codecov_url_secret: CODECOV_PUBLIC_QA_URL
+            codecov_token_secret: CODECOV_PUBLIC_QA_TOKEN
+            name: public qa
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coveragefiles-*
+          merge-multiple: true
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junitfiles-*
+          merge-multiple: true
+
+      - name: Uploading unit test coverage (${{ matrix.name }})
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./unit.*.coverage.xml
+          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          disable_search: true
+          # Strange workaround: API has a `codecov` directory in the repo root
+          # which conflicts with the action's `codecov` binary
+          use_pypi: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+
+      - name: Uploading integration test coverage (${{ matrix.name }})
+        if: ${{ inputs.run_integration == true }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./integration.*.coverage.xml
+          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          disable_search: true
+          # Strange workaround: API has a `codecov` directory in the repo root
+          # which conflicts with the action's `codecov` binary
+          use_pypi: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+
+      - name: Uploading unit test results (${{ matrix.name }})
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./unit.*.junit.xml
+          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          disable_search: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+          # The coverage action will have installed codecovcli with pip. The
+          # actual binary will be found in $PATH.
+          binary: codecovcli
+
+      - name: Uploading integration test results (${{ matrix.name }})
+        if: ${{ inputs.run_integration == true }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./integration.*.junit.xml
+          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          disable_search: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+          # The coverage action will have installed codecovcli with pip. The
+          # actual binary will be found in $PATH.
+          binary: codecovcli

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,9 @@ on:
       repo:
         type: string
         required: true
+      flag_prefix:
+        type: string
+        default: ''
 env:
   AR_REPO: ${{ inputs.repo }}
 
@@ -52,30 +55,101 @@ jobs:
         if: ${{ !cancelled() && inputs.run_integration == true }}
         run: |
           make test_env.run_integration
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: coveragefiles
+          path: ./*.coverage.xml
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: junitfiles
           path: ./*junit*.xml
-      ## Don't upload on forks for now.
-      - name: upload using codecovcli
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_URL }}
-      - name: upload using codecovcli staging
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_ORG_TOKEN_STAGING }} CODECOV_URL=${{ secrets.CODECOV_STAGING_URL }}
-      - name: upload using codecovcli qa
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_QA_URL }}
-      - name: upload using codecovcli public qa
-        if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        run: |
-          make test_env.upload CODECOV_UPLOAD_TOKEN=${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} CODECOV_URL=${{ secrets.CODECOV_PUBLIC_QA_URL }}
-      - name: run basic-test-results
-        if: ${{ !cancelled() && github.ref && contains(github.ref, 'pull') && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
-        uses: codecov/basic-test-results@v1
+
+  upload:
+    name: Upload to Codecov
+    runs-on: ubuntu-latest
+    needs: [test]
+    strategy:
+      matrix:
+        include:
+          - codecov_url_secret: CODECOV_URL
+            codecov_token_secret: CODECOV_ORG_TOKEN
+            name: prod
+          - codecov_url_secret: CODECOV_STAGING_URL
+            codecov_token_secret: CODECOV_ORG_TOKEN_STAGING
+            name: staging
+          - codecov_url_secret: CODECOV_QA_URL
+            codecov_token_secret: CODECOV_QA_ORG
+            name: qa
+          - codecov_url_secret: CODECOV_PUBLIC_QA_URL
+            codecov_token_secret: CODECOV_PUBLIC_QA_TOKEN
+            name: public qa
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coveragefiles
+
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          name: junitfiles
+
+      - name: Uploading unit test coverage (${{ matrix.name }})
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./unit.coverage.xml
+          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          disable_search: true
+          # Strange workaround: API has a `codecov` directory in the repo root
+          # which conflicts with the action's `codecov` binary
+          use_pypi: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+
+      - name: Uploading integration test coverage (${{ matrix.name }})
+        if: ${{ inputs.run_integration == true }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./integration.coverage.xml
+          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          disable_search: true
+          # Strange workaround: API has a `codecov` directory in the repo root
+          # which conflicts with the action's `codecov` binary
+          use_pypi: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+
+      - name: Uploading unit test results (${{ matrix.name }})
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./unit.junit.xml
+          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          disable_search: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+          # The coverage action will have installed codecovcli with pip. The
+          # actual binary will be found in $PATH.
+          binary: codecovcli
+
+      - name: Uploading integration test results (${{ matrix.name }})
+        if: ${{ inputs.run_integration == true }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ./integration.junit.xml
+          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          disable_search: true
+          token: ${{ secrets[matrix.codecov_token_secret] }}
+          url: ${{ secrets[matrix.codecov_url_secret] }}
+          # The coverage action will have installed codecovcli with pip. The
+          # actual binary will be found in $PATH.
+          binary: codecovcli


### PR DESCRIPTION
tl;dr:
- use regular codecov actions to upload coverage and test results, not the cli
- use a matrixed job to upload coverage/junit files to each of our environments concurrently

worker, shared, and API run their tests inside containers, but those containers all bindmount the working directory into the container. so when the tests write junit/coverage files, those files are visible outside of the container as well. this PR uploads those files with `upload-artifact`

a separate job uses `download-artifact` + a matrix to submit up to four uploads ({unit, integration} {coverage, junit}) to codecov in each of our four environments

`run-tests-split.yml` presents an extra complication. the tests are themselves run in a matrix and produce several output files. i've done a few things to deal with that:
- dynamically build the matrix for the test job based on the passed-in number of groups to split into, so now you can actually use the workflow with different split sizes
- assumed that each test job will include its group number in its output filenames. so for example: `unit.4.coverage.xml`, `integration.2.junit.xml`
- added the group index to the uploaded artifacts' keys as well, and used the `pattern` argument for `download-artifact` to download them all in one go
- provided globs to the `files` arg in the action, which i think will work

