### PR TITLE
fix: use project-scoped artifact names, return test job result as workflow output

### DIFF
--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -20,6 +20,11 @@ on:
       working_directory:
         type: string
         default: .
+    outputs:
+      tests_passed:
+        # Silly issue with returning job results as workflow outputs
+        # https://github.com/actions/runner/issues/2495
+        value: ${{ fromJSON(toJSON(jobs.test)).result }}
 
 env:
   AR_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -92,13 +92,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: coveragefiles-${{ matrix.group }}
+          name: ${{ inputs.flag_prefix }}-coveragefiles-${{ matrix.group }}
           path: ${{ inputs.working_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: junitfiles-${{ matrix.group }}
+          name: ${{ inputs.flag_prefix }}-junitfiles-${{ matrix.group }}
           path: ${{ inputs.working_directory }}/*junit*.xml
 
   upload:
@@ -135,14 +135,14 @@ jobs:
         id: download_coverage
         uses: actions/download-artifact@v4
         with:
-          pattern: coveragefiles-*
+          pattern: ${{ inputs.flag_prefix }}-coveragefiles-*
           merge-multiple: true
 
       - name: Download test results
         id: download_test_results
         uses: actions/download-artifact@v4
         with:
-          pattern: junitfiles-*
+          pattern: ${{ inputs.flag_prefix }}-junitfiles-*
           merge-multiple: true
 
       - name: Uploading unit test coverage (${{ matrix.name }})

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,11 @@ on:
       working_directory:
         type: string
         default: .
+    outputs:
+      tests_passed:
+        # Silly issue with returning job results as workflow outputs
+        # https://github.com/actions/runner/issues/2495
+        value: ${{ fromJSON(toJSON(jobs.test)).result }}
 
 env:
   AR_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,13 +67,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: coveragefiles
+          name: ${{ inputs.flag_prefix }}-coveragefiles
           path: ${{ inputs.working_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: junitfiles
+          name: ${{ inputs.flag_prefix }}-junitfiles
           path: ${{ inputs.working_directory }}/*junit*.xml
 
   upload:
@@ -110,13 +110,13 @@ jobs:
         id: download_coverage
         uses: actions/download-artifact@v4
         with:
-          name: coveragefiles
+          name: ${{ inputs.flag_prefix }}-coveragefiles
 
       - name: Download test results
         id: download_test_results
         uses: actions/download-artifact@v4
         with:
-          name: junitfiles
+          name: ${{ inputs.flag_prefix }}-junitfiles
 
       - name: Uploading unit test coverage (${{ matrix.name }})
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
two changes for https://github.com/codecov/umbrella/pull/12

first: umbrella now has a single workflow which runs worker, shared, and codecov-api workflows as subroutines. they, in turn, call these shared workflows which upload coverage and junit files with `coveragefiles` and `junitfiles` as their artifact names. worker and shared both try to use the same name and they fight. so, this change adds a prefix to the artifact name so there is no more conflict

second: each workflow now has an output variable that explicitly indicates whether tests passed. this is helpful for two reasons:
- when using `run-tests-split`, the workflow output is the simplest way to check whether any of the matrixed jobs failed
- we can make specifically the tests required and allow, like, the codecov upload jobs or whatever to fail if we want