### PR TITLE
use recurse_submodules cc action arg + remove working_directory cc action arg

### DIFF
--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -161,7 +161,7 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
-          working-directory: ${{ inputs.working_directory }}
+          recurse_submodules: true
 
       - name: Uploading integration test coverage (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
@@ -175,7 +175,7 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
-          working-directory: ${{ inputs.working_directory }}
+          recurse_submodules: true
 
       # The test result action doesn't accept globs in its `files` argument
       # so this step expands the globs into a comma-separated list of files

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -134,7 +134,7 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
-          working-directory: ${{ inputs.working_directory }}
+          recurse_submodules: true
 
       - name: Uploading integration test coverage (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
@@ -148,7 +148,7 @@ jobs:
           use_pypi: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
-          working-directory: ${{ inputs.working_directory }}
+          recurse_submodules: true
 
       - name: Uploading unit test results (${{ matrix.name }})
         uses: codecov/test-results-action@v1


### PR DESCRIPTION
needed for https://github.com/codecov/umbrella/pull/17

https://github.com/codecov/codecov-action/pull/1780 adds a `recurse_submodules` arg to the action which adds the `--recurse-submodules` arg to `git ls-files` when the CLI is building the network section.

this is necessary for umbrella because, at least while we migrate, worker/shared/api are submodules. we want coverage data for `apps/worker/tasks/base.py` etc so we need `git ls-files` to recurse into submodules when we're building the network section for umbrella uploads