### PR TITLE
add makefile prefix, custom reqs cache key args

### DIFF
--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -20,9 +20,12 @@ on:
         type: boolean
         default: true
         description: "Whether to push the image"
-      working_directory:
+      output_directory:
         type: string
         default: .
+      make_target_prefix:
+        type: string
+        default: ""
 
 env:
   DOCKERHUB_REPO: ${{ inputs.repo }}
@@ -33,9 +36,6 @@ jobs:
   build-and-push:
     name: Build and push
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,19 +50,19 @@ jobs:
           cache-name: cache-${{ inputs.image_name }}
         with:
           path: |
-            ${{ inputs.working_directory }}/${{ inputs.image_name }}.tar
+            ${{ inputs.output_directory }}/${{ inputs.image_name }}.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load built image
         if: ${{ inputs.cache && steps.cache-image.outputs.cache-hit == 'true' }}
         run: |
-          make load.${{ inputs.image_name }}
+          make ${{ inputs.make_target_prefix }}load.${{ inputs.image_name }}
 
       - name: Build image
         if: ${{ !inputs.cache || steps.cache-image.outputs.cache-hit != 'true' }}
         run: |
-          make build.${{ inputs.image_name }}
-          make save.${{ inputs.image_name }}
+          make ${{ inputs.make_target_prefix }}build.${{ inputs.image_name }}
+          make ${{ inputs.make_target_prefix }}save.${{ inputs.image_name }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
@@ -74,5 +74,5 @@ jobs:
       - name: Push image
         if: ${{ inputs.push && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          make tag.${{ inputs.image_name }}
-          make push.${{ inputs.image_name }}
+          make ${{ inputs.make_target_prefix }}tag.${{ inputs.image_name }}
+          make ${{ inputs.make_target_prefix }}push.${{ inputs.image_name }}

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,12 +9,18 @@ on:
       cache_requirements:
         type: boolean
         default: true
-      working_directory:
+      output_directory:
         type: string
         default: .
+      reqs_cache_key:
+        type: string
+        required: false
       cache_file:
         type: string
         default: "requirements.txt"
+      make_target_prefix:
+        type: string
+        default: ""
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -23,9 +29,6 @@ jobs:
   build:
     name: Build App
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,8 +57,8 @@ jobs:
           cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
-            ${{ inputs.working_directory }}/requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles(format('{0}/**/{1}', inputs.working_directory, inputs.cache_file)) }}-${{ hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.working_directory)) }}
+            ${{ inputs.output_directory }}/requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.reqs_cache_key || format('{0}-{1}', hashFiles(format('{0}/**/{1}', inputs.output_directory, inputs.cache_file)), hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.output_directory))) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -66,25 +69,25 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache
         if: ${{ steps.cache-requirements.outputs.cache-hit == 'true' && inputs.cache_requirements }}
         run: |
-          make load.requirements
+          make ${{ inputs.make_target_prefix }}load.requirements
 
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && inputs.cache_requirements }}
         run: |
-          make build.requirements
-          make save.requirements
+          make ${{ inputs.make_target_prefix }}build.requirements
+          make ${{ inputs.make_target_prefix }}save.requirements
 
       - name: Push Requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' && inputs.cache_requirements }}
         run: |
-          make push.requirements
+          make ${{ inputs.make_target_prefix }}push.requirements
       - name: Build app
         run: |
-          make build.app
-          make save.app
+          make ${{ inputs.make_target_prefix }}build.app
+          make ${{ inputs.make_target_prefix }}save.app

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,22 +4,19 @@ name: Run Lint
 on:
   workflow_call:
     inputs:
-      working_directory:
+      make_target_prefix:
         type: string
-        default: .
+        default: ""
 
 jobs:
   lint:
     name: Run Lint
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: Install dependencies
-        run: make lint.install
+        run: make ${{ inputs.make_target_prefix }}lint.install
       - name: Check
-        run: make lint.check
+        run: make ${{ inputs.make_target_prefix }}lint.check

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -21,9 +21,12 @@ on:
         type: boolean
         default: false
         description: "Whether to push the release image"
-      working_directory:
+      output_directory:
         type: string
         default: .
+      make_target_prefix:
+        type: string
+        default: ""
       sentry_project:
         type: string
         required: false
@@ -35,9 +38,6 @@ jobs:
   push-environment:
     name: Push ${{ inputs.environment }} Image
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     environment: ${{ inputs.environment }}
     if: github.repository_owner == 'codecov' && !inputs.push_rolling && !inputs.push_release
     steps:
@@ -58,7 +58,7 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -77,13 +77,13 @@ jobs:
 
       - name: Push ${{ inputs.environment }}
         run: |
-          make tag.${{ inputs.environment }}
-          make push.${{ inputs.environment }}
+          make ${{ inputs.make_target_prefix }}tag.${{ inputs.environment }}
+          make ${{ inputs.make_target_prefix }}push.${{ inputs.environment }}
       - name: Push latest
         if: inputs.environment == 'production'
         run: |
-          make tag.latest
-          make push.latest
+          make ${{ inputs.make_target_prefix }}tag.latest
+          make ${{ inputs.make_target_prefix }}push.latest
 
       - name: Create Sentry release
         if: inputs.create_sentry_release
@@ -96,14 +96,11 @@ jobs:
           environment: ${{ inputs.environment }}
           version: ${{ inputs.environment }}-release-${{ steps.sha.outputs.short_sha }}
           ignore_missing: true
-          working_directory: ${{ inputs.working_directory }}
+          output_directory: ${{ inputs.output_directory }}
   rolling:
     name: Push Rolling Image
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,7 +114,7 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -129,15 +126,12 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push Rolling
         run: |
-          make tag.rolling
-          make push.rolling
+          make ${{ inputs.make_target_prefix }}tag.rolling
+          make ${{ inputs.make_target_prefix }}push.rolling
   release:
     name: Push Release Image
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,7 +145,7 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
@@ -163,5 +157,5 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push release
         run: |
-          make tag.release
-          make push.release
+          make ${{ inputs.make_target_prefix }}tag.release
+          make ${{ inputs.make_target_prefix }}push.release

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -17,9 +17,12 @@ on:
       flag_prefix:
         type: string
         default: ''
-      working_directory:
+      output_directory:
         type: string
         default: .
+      make_target_prefix:
+        type: string
+        default: ""
       pytest_rootdir:
         type: string
         default: .
@@ -52,9 +55,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     needs: [prepare_groups]
     strategy:
       matrix:
@@ -73,48 +73,45 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input app.tar
+          docker load --input ${{ inputs.output_directory }}/app.tar
       - name: Install docker compose
         run: |
           sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Bring test env up
         run: |
-          make test_env.up
+          make ${{ inputs.make_target_prefix }}test_env.up
       - name: Prepare for tests
         run: |
-          make test_env.prepare
-          make test_env.check_db
+          make ${{ inputs.make_target_prefix }}test_env.prepare
+          make ${{ inputs.make_target_prefix }}test_env.check_db
       - name: Run unit tests
         run: |
-          make test_env.run_unit GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_unit GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
       - name: Run integration tests
         if: inputs.run_integration == true
         run: |
-          make test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.flag_prefix }}-coveragefiles-${{ matrix.group }}
-          path: ${{ inputs.working_directory }}/*.coverage.xml
+          path: ${{ inputs.output_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.flag_prefix }}-junitfiles-${{ matrix.group }}
-          path: ${{ inputs.working_directory }}/*junit*.xml
+          path: ${{ inputs.output_directory }}/*junit*.xml
 
   upload:
     name: Upload to Codecov
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     needs: [test]
     strategy:
       matrix:
@@ -205,7 +202,7 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.working_directory }}
+          working-directory: ${{ inputs.output_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
@@ -219,4 +216,4 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.working_directory }}
+          working-directory: ${{ inputs.output_directory }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,12 +13,15 @@ on:
       flag_prefix:
         type: string
         default: ''
-      working_directory:
-        type: string
-        default: .
       pytest_rootdir:
         type: string
         default: .
+      output_directory:
+        type: string
+        default: .
+      make_target_prefix:
+        type: string
+        default: ""
     outputs:
       tests_passed:
         # Silly issue with returning job results as workflow outputs
@@ -32,9 +35,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,48 +48,45 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.working_directory }}/app.tar
+            ${{ inputs.output_directory }}/app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input app.tar
+          docker load --input ${{ inputs.output_directory }}/app.tar
       - name: Install docker compose
         run: |
           sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Bring test env up
         run: |
-          make test_env.up
+          make ${{ inputs.make_target_prefix }}test_env.up
       - name: Prepare for tests
         run: |
-          make test_env.prepare
-          make test_env.check_db
+          make ${{ inputs.make_target_prefix }}test_env.prepare
+          make ${{ inputs.make_target_prefix }}test_env.check_db
       - name: Run unit tests
         run: |
-          make test_env.run_unit PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_unit PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
       - name: Run integration tests
         if: ${{ !cancelled() && inputs.run_integration == true }}
         run: |
-          make test_env.run_integration PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make ${{ inputs.make_target_prefix }}test_env.run_integration PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.flag_prefix }}-coveragefiles
-          path: ${{ inputs.working_directory }}/*.coverage.xml
+          path: ${{ inputs.output_directory }}/*.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.flag_prefix }}-junitfiles
-          path: ${{ inputs.working_directory }}/*junit*.xml
+          path: ${{ inputs.output_directory }}/*junit*.xml
 
   upload:
     name: Upload to Codecov
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     needs: [test]
     strategy:
       matrix:
@@ -164,7 +161,7 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.working_directory }}
+          working-directory: ${{ inputs.output_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
@@ -178,4 +175,4 @@ jobs:
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.working_directory }}
+          working-directory: ${{ inputs.output_directory }}

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -19,9 +19,15 @@ on:
       cache_file:
         type: string
         default: "requirements.txt"
-      working_directory:
+      output_directory:
         type: string
         default: .
+      reqs_cache_key:
+        type: string
+        required: false
+      make_target_prefix:
+        type: string
+        default: ""
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -30,9 +36,6 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted App
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,8 +64,8 @@ jobs:
           cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
-            ${{ inputs.working_directory }}/requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles(format('{0}/**/{1}', inputs.working_directory, inputs.cache_file)) }}-${{ hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.working_directory)) }}
+            ${{ inputs.output_directory }}/requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.reqs_cache_key || format('{0}-{1}', hashFiles(format('{0}/**/{1}', inputs.output_directory, inputs.cache_file)), hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.output_directory))) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -73,39 +76,36 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.working_directory }}/self-hosted-runtime.tar
-            ${{ inputs.working_directory }}/self-hosted.tar
+            ${{ inputs.output_directory }}/self-hosted-runtime.tar
+            ${{ inputs.output_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache
         if: ${{ steps.cache-requirements.outputs.cache-hit == 'true' && inputs.cache_requirements }}
         run: |
-          make load.requirements
+          make ${{ inputs.make_target_prefix }}load.requirements
 
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && inputs.cache_requirements }}
         run: |
-          make build.requirements
+          make ${{ inputs.make_target_prefix }}build.requirements
 
       - name: Load built image
         if: ${{ steps.cache-self-hosted.outputs.cache-hit == 'true' }}
         run: |
-          make load.self-hosted
+          make ${{ inputs.make_target_prefix }}load.self-hosted
 
       - name: Build self hosted
         if: ${{ steps.cache-self-hosted.outputs.cache-hit != 'true' }}
         run: |
-          make build.self-hosted
-          make save.self-hosted
+          make ${{ inputs.make_target_prefix }}build.self-hosted
+          make ${{ inputs.make_target_prefix }}save.self-hosted
 
   self-hosted:
     name: Push Self Hosted Image
     needs: [build-self-hosted]
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     environment: self-hosted
     steps:
       - name: Checkout
@@ -120,12 +120,12 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.working_directory }}/self-hosted-runtime.tar
-            ${{ inputs.working_directory }}/self-hosted.tar
+            ${{ inputs.output_directory }}/self-hosted-runtime.tar
+            ${{ inputs.output_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          make load.self-hosted
+          make ${{ inputs.make_target_prefix }}load.self-hosted
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -133,16 +133,13 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push Self Hosted Rolling
         run: |
-          make tag.self-hosted-rolling
-          make push.self-hosted-rolling
+          make ${{ inputs.make_target_prefix }}tag.self-hosted-rolling
+          make ${{ inputs.make_target_prefix }}push.self-hosted-rolling
   self-hosted-release:
     name: Push Self Hosted Release Image
     needs: [build-self-hosted]
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
     environment: self-hosted
     steps:
       - name: Checkout
@@ -157,12 +154,12 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.working_directory }}/self-hosted-runtime.tar
-            ${{ inputs.working_directory }}/self-hosted.tar
+            ${{ inputs.output_directory }}/self-hosted-runtime.tar
+            ${{ inputs.output_directory }}/self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          make load.self-hosted
+          make ${{ inputs.make_target_prefix }}load.self-hosted
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -170,5 +167,5 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push self hosted release
         run: |
-          make tag.self-hosted-release
-          make push.self-hosted-release
+          make ${{ inputs.make_target_prefix }}tag.self-hosted-release
+          make ${{ inputs.make_target_prefix }}push.self-hosted-release


### PR DESCRIPTION
needed for https://github.com/codecov/umbrella/pull/30

previously i added `working_directory` to these workflows so that umbrella could make each one run `cd apps/worker` or similar at the beginning. it turns out, however, that we need to build requirements images in the umbrella root rather than `apps/worker` etc. so this PR replaces `working_directory` with a new `make_target_prefix` argument: if the workflow ordinarily calls `make build`, umbrella can use this argument to make it call `make worker.build`

unfortunately, i couldn't completely get rid of the old `working_directory`. with the way things are set up, things like `app.tar` or `junit.xml` are still dumped in `apps/worker`. so i renamed the argument `output_directory` to match its new function

finally, this PR adds the `reqs_cache_key` argument to `build-app.yml` and `self-hosted.yml`. this allows umbrella to pass in a special cache key for its special requirements images which include an extra hash. if the argument isn't provided, the cache key is computed like normal.