### PR TITLE
chore: remove all of the workflow args used for cutover

### DIFF
--- a/.github/workflows/build-and-push-dockerhub.yml
+++ b/.github/workflows/build-and-push-dockerhub.yml
@@ -20,12 +20,6 @@ on:
         type: boolean
         default: true
         description: "Whether to push the image"
-      output_directory:
-        type: string
-        default: .
-      make_target_prefix:
-        type: string
-        default: ""
 
 env:
   DOCKERHUB_REPO: ${{ inputs.repo }}
@@ -50,19 +44,19 @@ jobs:
           cache-name: cache-${{ inputs.image_name }}
         with:
           path: |
-            ${{ inputs.output_directory }}/${{ inputs.image_name }}.tar
+            ${{ inputs.image_name }}.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load built image
         if: ${{ inputs.cache && steps.cache-image.outputs.cache-hit == 'true' }}
         run: |
-          make ${{ inputs.make_target_prefix }}load.${{ inputs.image_name }}
+          make load.${{ inputs.image_name }}
 
       - name: Build image
         if: ${{ !inputs.cache || steps.cache-image.outputs.cache-hit != 'true' }}
         run: |
-          make ${{ inputs.make_target_prefix }}build.${{ inputs.image_name }}
-          make ${{ inputs.make_target_prefix }}save.${{ inputs.image_name }}
+          make build.${{ inputs.image_name }}
+          make save.${{ inputs.image_name }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
@@ -74,5 +68,5 @@ jobs:
       - name: Push image
         if: ${{ inputs.push && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          make ${{ inputs.make_target_prefix }}tag.${{ inputs.image_name }}
-          make ${{ inputs.make_target_prefix }}push.${{ inputs.image_name }}
+          make tag.${{ inputs.image_name }}
+          make push.${{ inputs.image_name }}

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -9,18 +9,9 @@ on:
       cache_requirements:
         type: boolean
         default: true
-      output_directory:
-        type: string
-        default: .
-      reqs_cache_key:
-        type: string
-        required: false
       cache_file:
         type: string
         default: "requirements.txt"
-      make_target_prefix:
-        type: string
-        default: ""
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -57,8 +48,8 @@ jobs:
           cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
-            ${{ inputs.output_directory }}/requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.reqs_cache_key || format('{0}-{1}', hashFiles(format('{0}/**/{1}', inputs.output_directory, inputs.cache_file)), hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.output_directory))) }}
+            requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ format('{0}-{1}', hashFiles(format('./**/{1}', inputs.cache_file)), hashFiles('./**/docker/Dockerfile.requirements')) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -69,25 +60,25 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache
         if: ${{ steps.cache-requirements.outputs.cache-hit == 'true' && inputs.cache_requirements }}
         run: |
-          make ${{ inputs.make_target_prefix }}load.requirements
+          make load.requirements
 
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && inputs.cache_requirements }}
         run: |
-          make ${{ inputs.make_target_prefix }}build.requirements
-          make ${{ inputs.make_target_prefix }}save.requirements
+          make build.requirements
+          make save.requirements
 
       - name: Push Requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' && inputs.cache_requirements }}
         run: |
-          make ${{ inputs.make_target_prefix }}push.requirements
+          make push.requirements
       - name: Build app
         run: |
-          make ${{ inputs.make_target_prefix }}build.app
-          make ${{ inputs.make_target_prefix }}save.app
+          make build.app
+          make save.app

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,6 @@ name: Run Lint
 
 on:
   workflow_call:
-    inputs:
-      make_target_prefix:
-        type: string
-        default: ""
 
 jobs:
   lint:
@@ -17,6 +13,6 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Install dependencies
-        run: make ${{ inputs.make_target_prefix }}lint.install
+        run: make lint.install
       - name: Check
-        run: make ${{ inputs.make_target_prefix }}lint.check
+        run: make lint.check

--- a/.github/workflows/push-env.yml
+++ b/.github/workflows/push-env.yml
@@ -21,12 +21,6 @@ on:
         type: boolean
         default: false
         description: "Whether to push the release image"
-      output_directory:
-        type: string
-        default: .
-      make_target_prefix:
-        type: string
-        default: ""
       sentry_project:
         type: string
         required: false
@@ -58,11 +52,11 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input app.tar
       - id: "auth"
         name: "Authenticate to Google Cloud"
         uses: "google-github-actions/auth@v2.1.2"
@@ -77,13 +71,13 @@ jobs:
 
       - name: Push ${{ inputs.environment }}
         run: |
-          make ${{ inputs.make_target_prefix }}tag.${{ inputs.environment }}
-          make ${{ inputs.make_target_prefix }}push.${{ inputs.environment }}
+          make tag.${{ inputs.environment }}
+          make push.${{ inputs.environment }}
       - name: Push latest
         if: inputs.environment == 'production'
         run: |
-          make ${{ inputs.make_target_prefix }}tag.latest
-          make ${{ inputs.make_target_prefix }}push.latest
+          make tag.latest
+          make push.latest
 
       - name: Create Sentry release
         if: inputs.create_sentry_release
@@ -96,7 +90,6 @@ jobs:
           environment: ${{ inputs.environment }}
           version: ${{ inputs.environment }}-release-${{ steps.sha.outputs.short_sha }}
           ignore_missing: true
-          output_directory: ${{ inputs.output_directory }}
   rolling:
     name: Push Rolling Image
     if: inputs.push_rolling == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
@@ -114,11 +107,11 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input app.tar
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -126,8 +119,8 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push Rolling
         run: |
-          make ${{ inputs.make_target_prefix }}tag.rolling
-          make ${{ inputs.make_target_prefix }}push.rolling
+          make tag.rolling
+          make push.rolling
   release:
     name: Push Release Image
     if: inputs.push_release == true && github.repository_owner == 'codecov' && !github.event.pull_request.head.repo.fork
@@ -145,11 +138,11 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input app.tar
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -157,5 +150,5 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push release
         run: |
-          make ${{ inputs.make_target_prefix }}tag.release
-          make ${{ inputs.make_target_prefix }}push.release
+          make tag.release
+          make push.release

--- a/.github/workflows/run-tests-split.yml
+++ b/.github/workflows/run-tests-split.yml
@@ -14,18 +14,6 @@ on:
         type: number
         required: false
         default: 5
-      flag_prefix:
-        type: string
-        default: ''
-      output_directory:
-        type: string
-        default: .
-      make_target_prefix:
-        type: string
-        default: ""
-      pytest_rootdir:
-        type: string
-        default: .
     outputs:
       tests_passed:
         # Silly issue with returning job results as workflow outputs
@@ -73,41 +61,41 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input app.tar
       - name: Install docker compose
         run: |
           sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Bring test env up
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.up
+          make test_env.up
       - name: Prepare for tests
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.prepare
-          make ${{ inputs.make_target_prefix }}test_env.check_db
+          make test_env.prepare
+          make test_env.check_db
       - name: Run unit tests
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_unit GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make test_env.run_unit GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }}
       - name: Run integration tests
         if: inputs.run_integration == true
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }} PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make test_env.run_integration GROUP=${{ matrix.group }} SPLIT=${{ inputs.split }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ inputs.flag_prefix }}-coveragefiles-${{ matrix.group }}
-          path: ${{ inputs.output_directory }}/*.coverage.xml
+          name: coveragefiles-${{ matrix.group }}
+          path: *.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ inputs.flag_prefix }}-junitfiles-${{ matrix.group }}
-          path: ${{ inputs.output_directory }}/*junit*.xml
+          name: junitfiles-${{ matrix.group }}
+          path: *junit*.xml
 
   upload:
     name: Upload to Codecov
@@ -140,21 +128,21 @@ jobs:
         id: download_coverage
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.flag_prefix }}-coveragefiles-*
+          pattern: coveragefiles-*
           merge-multiple: true
 
       - name: Download test results
         id: download_test_results
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ inputs.flag_prefix }}-junitfiles-*
+          pattern: junitfiles-*
           merge-multiple: true
 
       - name: Uploading unit test coverage (${{ matrix.name }})
         uses: codecov/codecov-action@v5
         with:
           files: ${{ steps.download_coverage.outputs.download-path }}/unit.*.coverage.xml
-          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          flags: unit
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
           # which conflicts with the action's `codecov` binary
@@ -168,7 +156,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ${{ steps.download_coverage.outputs.download-path }}/integration.*.coverage.xml
-          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          flags: integration
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
           # which conflicts with the action's `codecov` binary
@@ -195,25 +183,23 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           files: ${{ steps.junit_files.outputs.unit_junit_files }}
-          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          flags: unit
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.output_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/test-results-action@v1
         with:
           files: ${{ steps.junit_files.outputs.integration_junit_files }}
-          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          flags: integration
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.output_directory }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,18 +10,6 @@ on:
       repo:
         type: string
         required: true
-      flag_prefix:
-        type: string
-        default: ''
-      pytest_rootdir:
-        type: string
-        default: .
-      output_directory:
-        type: string
-        default: .
-      make_target_prefix:
-        type: string
-        default: ""
     outputs:
       tests_passed:
         # Silly issue with returning job results as workflow outputs
@@ -48,41 +36,41 @@ jobs:
           cache-name: ${{ inputs.repo }}-app
         with:
           path: |
-            ${{ inputs.output_directory }}/app.tar
+            app.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          docker load --input ${{ inputs.output_directory }}/app.tar
+          docker load --input app.tar
       - name: Install docker compose
         run: |
           sudo curl -SL https://github.com/docker/compose/releases/download/v2.20.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       - name: Bring test env up
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.up
+          make test_env.up
       - name: Prepare for tests
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.prepare
-          make ${{ inputs.make_target_prefix }}test_env.check_db
+          make test_env.prepare
+          make test_env.check_db
       - name: Run unit tests
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_unit PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make test_env.run_unit
       - name: Run integration tests
         if: ${{ !cancelled() && inputs.run_integration == true }}
         run: |
-          make ${{ inputs.make_target_prefix }}test_env.run_integration PYTEST_ROOTDIR=${{ inputs.pytest_rootdir }}
+          make test_env.run_integration
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ inputs.flag_prefix }}-coveragefiles
-          path: ${{ inputs.output_directory }}/*.coverage.xml
+          name: coveragefiles
+          path: *.coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: ${{ inputs.flag_prefix }}-junitfiles
-          path: ${{ inputs.output_directory }}/*junit*.xml
+          name: junitfiles
+          path: *junit*.xml
 
   upload:
     name: Upload to Codecov
@@ -115,19 +103,19 @@ jobs:
         id: download_coverage
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.flag_prefix }}-coveragefiles
+          name: coveragefiles
 
       - name: Download test results
         id: download_test_results
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.flag_prefix }}-junitfiles
+          name: junitfiles
 
       - name: Uploading unit test coverage (${{ matrix.name }})
         uses: codecov/codecov-action@v5
         with:
           files: ${{ steps.download_coverage.outputs.download-path }}/unit.coverage.xml
-          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          flags: unit
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
           # which conflicts with the action's `codecov` binary
@@ -141,7 +129,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ${{ steps.download_coverage.outputs.download-path }}/integration.coverage.xml
-          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          flags: integration
           disable_search: true
           # Strange workaround: API has a `codecov` directory in the repo root
           # which conflicts with the action's `codecov` binary
@@ -154,25 +142,23 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           files: ${{ steps.download_test_results.outputs.download-path }}/unit.junit.xml
-          flags: ${{ format('{0}unit', inputs.flag_prefix) }}
+          flags: unit
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.output_directory }}
 
       - name: Uploading integration test results (${{ matrix.name }})
         if: ${{ inputs.run_integration == true }}
         uses: codecov/test-results-action@v1
         with:
           files: ${{ steps.download_test_results.outputs.download-path }}/integration.junit.xml
-          flags: ${{ format('{0}integration', inputs.flag_prefix) }}
+          flags: integration
           disable_search: true
           token: ${{ secrets[matrix.codecov_token_secret] }}
           url: ${{ secrets[matrix.codecov_url_secret] }}
           # The coverage action will have installed codecovcli with pip. The
           # actual binary will be found in $PATH.
           binary: codecovcli
-          working-directory: ${{ inputs.output_directory }}

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -19,15 +19,6 @@ on:
       cache_file:
         type: string
         default: "requirements.txt"
-      output_directory:
-        type: string
-        default: .
-      reqs_cache_key:
-        type: string
-        required: false
-      make_target_prefix:
-        type: string
-        default: ""
 
 env:
   AR_REPO: ${{ inputs.repo }}
@@ -64,8 +55,8 @@ jobs:
           cache-name: ${{ inputs.repo }}-requirements
         with:
           path: |
-            ${{ inputs.output_directory }}/requirements.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ inputs.reqs_cache_key || format('{0}-{1}', hashFiles(format('{0}/**/{1}', inputs.output_directory, inputs.cache_file)), hashFiles(format('{0}/**/docker/Dockerfile.requirements', inputs.output_directory))) }}
+            requirements.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ format('{0}-{1}', hashFiles(format('./**/{1}', inputs.cache_file)), hashFiles('./**/docker/Dockerfile.requirements')) }}
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
@@ -76,30 +67,30 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.output_directory }}/self-hosted-runtime.tar
-            ${{ inputs.output_directory }}/self-hosted.tar
+            self-hosted-runtime.tar
+            self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Load requirements from cache
         if: ${{ steps.cache-requirements.outputs.cache-hit == 'true' && inputs.cache_requirements }}
         run: |
-          make ${{ inputs.make_target_prefix }}load.requirements
+          make load.requirements
 
       - name: Build/pull requirements
         if: ${{ steps.cache-requirements.outputs.cache-hit != 'true' && inputs.cache_requirements }}
         run: |
-          make ${{ inputs.make_target_prefix }}build.requirements
+          make build.requirements
 
       - name: Load built image
         if: ${{ steps.cache-self-hosted.outputs.cache-hit == 'true' }}
         run: |
-          make ${{ inputs.make_target_prefix }}load.self-hosted
+          make load.self-hosted
 
       - name: Build self hosted
         if: ${{ steps.cache-self-hosted.outputs.cache-hit != 'true' }}
         run: |
-          make ${{ inputs.make_target_prefix }}build.self-hosted
-          make ${{ inputs.make_target_prefix }}save.self-hosted
+          make build.self-hosted
+          make save.self-hosted
 
   self-hosted:
     name: Push Self Hosted Image
@@ -120,12 +111,12 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.output_directory }}/self-hosted-runtime.tar
-            ${{ inputs.output_directory }}/self-hosted.tar
+            self-hosted-runtime.tar
+            self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          make ${{ inputs.make_target_prefix }}load.self-hosted
+          make load.self-hosted
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -133,8 +124,8 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push Self Hosted Rolling
         run: |
-          make ${{ inputs.make_target_prefix }}tag.self-hosted-rolling
-          make ${{ inputs.make_target_prefix }}push.self-hosted-rolling
+          make tag.self-hosted-rolling
+          make push.self-hosted-rolling
   self-hosted-release:
     name: Push Self Hosted Release Image
     needs: [build-self-hosted]
@@ -154,12 +145,12 @@ jobs:
           cache-name: ${{ inputs.repo }}-self-hosted
         with:
           path: |
-            ${{ inputs.output_directory }}/self-hosted-runtime.tar
-            ${{ inputs.output_directory }}/self-hosted.tar
+            self-hosted-runtime.tar
+            self-hosted.tar
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.run_id }}
       - name: Load built image
         run: |
-          make ${{ inputs.make_target_prefix }}load.self-hosted
+          make load.self-hosted
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -167,5 +158,5 @@ jobs:
           password: ${{ secrets.CODECOV_DEVOPS_DOCKER_PASSWORD }}
       - name: Push self hosted release
         run: |
-          make ${{ inputs.make_target_prefix }}tag.self-hosted-release
-          make ${{ inputs.make_target_prefix }}push.self-hosted-release
+          make tag.self-hosted-release
+          make push.self-hosted-release


### PR DESCRIPTION
a lot of ~hacks~ extra arguments were added to these workflows to allow them to be used by both `umbrella` and the repos merging into it to minimize differences while we were working on cutting over to the monorepo. as of https://github.com/codecov/umbrella/pull/88, `umbrella` no longer uses these workflows, so we can remove those extra arguments

worker/api/shared are frozen but there are still other repositories that use these workflows and they would probably appreciate them being cleaned up: https://github.com/search?q=org%3Acodecov+%2Fcodecov%5C%2Fgha-workflows%2F&type=code